### PR TITLE
Added resources to be copied during setup.py install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include demo/fonts/*.ttf
+include demo/images/*.png
+

--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,6 @@ setup(
     author_email='dcreemer@zachary.com',
     url='https://github.com/dcreemer/flipdot',
     license=license,
-    packages=find_packages(exclude=('tests', 'docs'))
+    packages=find_packages(exclude=('tests', 'docs')),
+    include_package_data=True
 )


### PR DESCRIPTION
Thanks for providing this library @dcreemer. I tested both the sim and with the flipdot_xy5 board, recently and works great.

Currently, if you run python setup.py install, it does not copy the images and fonts. Consequently importing demo (or animations) fails as the images are not present inside of site-packages after installation. This PR fixes the issue by adding the resources in the MANIFEST.in file, so setup can copy them.